### PR TITLE
Bug fixed for order not auto-captured and version bump 2.3.2

### DIFF
--- a/razorpay/CHANGELOG.md
+++ b/razorpay/CHANGELOG.md
@@ -5,6 +5,11 @@ Razorpay Prestashop Plugin Changelog
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2019-12-09
+
+### Changed
+- Bug fixed for order captured
+
 ## [2.3.1] - 2019-12-05
 
 ### Changed

--- a/razorpay/config.xml
+++ b/razorpay/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>razorpay</name>
     <displayName><![CDATA[Razorpay]]></displayName>
-    <version><![CDATA[2.3.1]]></version>
+    <version><![CDATA[2.3.2]]></version>
     <description><![CDATA[Accept payments with Razorpay]]></description>
     <author><![CDATA[Team Razorpay]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/razorpay/controllers/front/order.php
+++ b/razorpay/controllers/front/order.php
@@ -17,7 +17,7 @@ class RazorpayOrderModuleFrontController extends ModuleFrontController
             exit;
         }
 
-        $payment_action = Configuration::get('RAZORPAY_KEY_ID');
+        $payment_action = Configuration::get('RAZORPAY_PAYMENT_ACTION');
 
         $amount = number_format(($this->context->cart->getOrderTotal() * 100), 0, "", "");
 

--- a/razorpay/controllers/front/order.php
+++ b/razorpay/controllers/front/order.php
@@ -17,7 +17,7 @@ class RazorpayOrderModuleFrontController extends ModuleFrontController
             exit;
         }
 
-        $payment_action = Configuration::get('RAZORPAY_PAYMENT_ACTION');
+        $payment_action = Configuration::get('RAZORPAY_PAYMENT_ACTION') ?? Razorpay::CAPTURE;
 
         $amount = number_format(($this->context->cart->getOrderTotal() * 100), 0, "", "");
 

--- a/razorpay/razorpay.php
+++ b/razorpay/razorpay.php
@@ -26,7 +26,7 @@ class Razorpay extends PaymentModule
         $this->name = 'razorpay';
         $this->displayName = 'Razorpay';
         $this->tab = 'payments_gateways';
-        $this->version = '2.3.1';
+        $this->version = '2.3.2';
         $this->need_instance = 1;
         $this->ps_versions_compliancy = ['min' => '1.7.0.0', 'max' => _PS_VERSION_];
         $this->display = true;


### PR DESCRIPTION
Fixed issue for reading the 'Payment action' configuration to create Razorpay order and set payment capture action correctly.

`https://github.com/razorpay/razorpay-prestashop/pull/38`