### PR TITLE
Fixed warning after compilation of smarty

### DIFF
--- a/razorpay/views/templates/admin/admin.tpl
+++ b/razorpay/views/templates/admin/admin.tpl
@@ -20,7 +20,7 @@
       color: blue;
    }
 </style>
-<p><form action='{$_SERVER['REQUEST_URI']}' method='post'>
+<p><form action='{$smarty.server.REQUEST_URI}' method='post'>
    <fieldset style='background-color:white;'>
        <legend>
            <img src='../img/admin/edit.gif' />{$modrazorpay}


### PR DESCRIPTION
It was showing warming in backend configuration page. And form was not coming with action attribute in it.

<img width="612" alt="Screenshot 2023-07-07 at 3 09 48 PM" src="https://github.com/razorpay/razorpay-prestashop/assets/3338156/39cd42df-d5c4-48ea-af45-e3eb631466c7">
Warning on line 46 in file /var/www/html/var/cache/dev/smarty/compile/at_movic/09/b7/86/09b786e1b751e5f68c162ec647c93cd64d338f85_0.module.razorpayviewstemplatesadminadmin.tpl.php [2] Undefined array key "_SERVER"

Warning on line 46 in file /var/www/html/var/cache/dev/smarty/compile/at_movic/09/b7/86/09b786e1b751e5f68c162ec647c93cd64d338f85_0.module.razorpayviewstemplatesadminadmin.tpl.php [2] Attempt to read property "value" on null

Warning on line 46 in file /var/www/html/var/cache/dev/smarty/compile/at_movic/09/b7/86/09b786e1b751e5f68c162ec647c93cd64d338f85_0.module.razorpayviewstemplatesadminadmin.tpl.php [2] Trying to access array offset on value of type null

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |
No big document requried for test case. Just install the extension and go to configuration page. Make sure debig mode is enabled.


