### PR TITLE
SOLVED: The payment id provided is null - Razorpay | 

### DIFF
--- a/razorpay/script.js
+++ b/razorpay/script.js
@@ -119,35 +119,34 @@ document.addEventListener('DOMContentLoaded', function(event) {
 
 
   var parent = document.querySelector('#checkout-payment-step');
+  
+  function updateRazorpayButtonState() {
+    var selected = parent.querySelector('input[data-module-name="razorpay"]')?.checked;
 
-  parent.addEventListener(
-    'change',
-    function(e) {
-      var target = e.target;
-      var type = target.type;
+    if (selected) {
+      newSubmitButton.className = baseClass + 'shown';
+    } else {
+      newSubmitButton.className = baseClass + 'not-shown';
+    }
 
-      // We switch the buttons whenever a radio button (payment method)
-      // or a checkbox (conditions) is changed
-      if (
-        (target.getAttribute('data-module-name') && type === 'radio') ||
-        type === 'checkbox'
-      ) {
-        var selected = this.querySelector('input[data-module-name="razorpay"]')
-          .checked;
+    newSubmitButton.disabled = !!document.querySelector(
+      'input[name^=conditions_to_approve]:not(:checked)'
+    );
+  }
 
-        if (selected) {
-          newSubmitButton.className = baseClass + 'shown';
-        } else {
-          newSubmitButton.className = baseClass + 'not-shown';
-        }
+  // Run once on page load
+  updateRazorpayButtonState();
 
-        // This returns the first condition that is not checked
-        // and works as a truthy value
-        newSubmitButton.disabled = !!document.querySelector(
-          'input[name^=conditions_to_approve]:not(:checked)'
-        );
-      }
-    },
-    true
-  );
+  // Listen to user changes
+  parent.addEventListener('change', function (e) {
+    var target = e.target;
+    var type = target.type;
+
+    if (
+      (target.getAttribute('data-module-name') && type === 'radio') ||
+      type === 'checkbox'
+    ) {
+      updateRazorpayButtonState();
+    }
+  }, true);
 });


### PR DESCRIPTION
## 🐞 Bug Fix: Razorpay - "The payment id provided is null" when it is the only payment method

### 🔴 Problem:
When **Razorpay is the only available payment method**, PrestaShop auto-selects it by default. However, since the user never actively changes the selection, the `change` event listener does **not trigger**, and the default order button remains visible on the page.

As a result, clicking "Place Order" causes the following error:

```yaml
Order Id: 31  
Razorpay Payment Id:  
Error: The payment id provided is null
```

### ✅ What This PR Does:
- Fixes the issue by **calling the button visibility logic on page load**, even if the user doesn’t interact with the payment method section.
- Ensures the **correct Razorpay pay button** is shown immediately if Razorpay is auto-selected.

### 🛠️ Technical Changes:
- Added a call to `updateRazorpayButtonState()` inside a `DOMContentLoaded` or on initial script run.
- Preserves existing logic for `change` event listener for dynamic interactions.
- Prevents false submission through the default button.

### 🧪 Tested On:
- PrestaShop 8.2.1
- Razorpay module version 2.5.5
- Scenario where Razorpay is the **only enabled payment method**

### 💬 Additional Notes:
This is a minor UX fix but critical for proper payment flow. Without this, users may unknowingly click the wrong button and receive a null `razorpay_payment_id`, breaking the checkout experience.